### PR TITLE
Add Android.mk to build as part of roms.

### DIFF
--- a/com.google.android.maps/Android.mk
+++ b/com.google.android.maps/Android.mk
@@ -1,0 +1,19 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := com.google.android.maps
+LOCAL_MODULE_TAGS := optional
+LOCAL_SRC_FILES := $(call all-java-files-under, src)
+LOCAL_PACKAGE_NAME := com.google.android.maps
+LOCAL_CERTIFICATE := platform
+LOCAL_SDK_VERSION := current
+include $(BUILD_JAVA_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := com.google.android.maps.xml
+LOCAL_MODULE_TAGS := optional
+LOCAL_MODULE_CLASS := ETC
+LOCAL_MODULE_PATH := $(TARGET_OUT_ETC)/permissions
+LOCAL_SRC_FILES := in/$(LOCAL_MODULE)
+include $(BUILD_PREBUILT)
+


### PR DESCRIPTION
Hi,

attached patch adds the ability to build the maps api as part of a rom. It pushes the permissions file and writes the jar to the correct location.

I did not add the addon.d files as it should not be used in this case:
- If you switch roms you'll most likely either use the prebuild mapsapi (which contains an addons.d) or gapps which would cause trouble with addons.d
- If you upgrade your ROM you should be getting a new version of the files anyway

The products list must be extended by com.google.android.maps and com.google.android.maps.xml
